### PR TITLE
Clean up all fetch/ocaml-backend-* directories

### DIFF
--- a/src/SonicScout_Setup/Clean.ml
+++ b/src/SonicScout_Setup/Clean.ml
@@ -26,8 +26,8 @@ let clean (_ : Tr1Logs_Term.TerminalCliOptions.t) areas =
           |> Utils.rmsg
       | _ -> ()
     end;
-    ScoutBackend.clean areas;
     ScoutAndroid.clean areas;
+    ScoutBackend.clean areas;
     Utils.done_steps "Cleaning"
   with Utils.StopProvisioning -> ()
 


### PR DESCRIPTION
When running './dk SonicScout_Setup.Clean --dksdk-source-code' the:

  us\SonicScoutAndroid\fetch\ocaml-backend-*

directories were not being deleted.