### PR TITLE
Fix: Use a reliable qt mirror

### DIFF
--- a/src/SonicScout_Setup/Qt.ml
+++ b/src/SonicScout_Setup/Qt.ml
@@ -1,4 +1,6 @@
-let qt5_ver = "5.15.2"
+(** https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5152/Updates.xml *)
+let qt_ver, qt_downloadver, qt_updatever =
+  ("5.15.2", "qt5_5152", "5.15.2-0-202011130602")
 
 let clean areas =
   let open Bos in
@@ -7,23 +9,29 @@ let clean areas =
   if List.mem `QtInstallation areas then begin
     Utils.start_step "Cleaning SonicScoutBackend Qt installation";
     DkFs_C99.Path.rm ~recurse:() ~force:() ~kill:()
-      Fpath.[ projectdir / qt5_ver ]
+      Fpath.[ projectdir / qt_ver ]
     |> Utils.rmsg
   end
 
 let tools_dir ~projectdir = Fpath.(projectdir / ".tools")
 
 type qt_locations = {
-  host : string;
-  target : string;  (** [target] is the `aqt` target to download  *)
-  qt5_ver : string;
-  subdir : string;
-      (** [subdir] is the subdirectory under the QT5 version {!qt5_ver}  *)
+  aqt_host : string;
+  aqt_target : string;  (** [aqt_target] is the `aqt` target to download  *)
+  aqt_subdir : string;
+      (** [aqt_subdir] is the subdirectory under the QT5 version {!qt_ver}  *)
+  qt_ver : string;
+  qt_abi : string;
+      (** [qt_abi] is the ["windows_x86"] in ["https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5152/Updates.xml"] *)
+  qt_downloadver : string;
+      (** [qt_downloadver] is the ["qt5_5152"] in ["https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt5_5152/Updates.xml"] *)
+  qt_updatever : string;
+      (** [qt_updatever] is the ["5.15.2-0-202011130602"] in ["<Version>5.15.2-0-202011130602</Version>"] of the ["Updates.xml"]. *)
 }
 
-let qt_locations () =
-  let host, target, subdir =
-    match Tr1HostMachine.abi with
+let qt_locations ?host_abi () =
+  let aqt_host, aqt_target, aqt_subdir =
+    match Option.value host_abi ~default:Tr1HostMachine.abi with
     | `darwin_x86_64 | `darwin_arm64 -> ("mac", "clang_64", "clang_64")
     | `windows_x86_64 | `windows_x86 ->
         ("windows", "win64_msvc2019_64", "msvc2019_64")
@@ -31,9 +39,135 @@ let qt_locations () =
     | _ ->
         failwith "Currently your host machine is not supported by Sonic Scout"
   in
-  { host; target; qt5_ver; subdir }
+  let qt_abi =
+    (* https://github.com/miurahr/aqtinstall/blob/7917b2d725f56e8ceb6ba17b41ea0571506c7320/aqt/archives.py#L408-L421 *)
+    (* http://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/ *)
+    match Tr1HostMachine.abi with
+    | `android_arm32v7a | `android_arm64v8a | `android_x86 | `android_x86_64 ->
+        "all_os"
+    | `darwin_x86_64 | `darwin_arm64 -> "mac_x64"
+    | `windows_x86_64 | `windows_x86 -> "windows_x86"
+    | `windows_arm64 -> "windows_arm64"
+    | `linux_x86_64 -> "linux_x64"
+    | `linux_arm64 -> "linux_arm64"
+    | _ ->
+        failwith "Currently your host machine is not supported by Sonic Scout"
+  in
+  {
+    aqt_host;
+    aqt_target;
+    aqt_subdir;
+    qt_abi;
+    qt_ver;
+    qt_downloadver;
+    qt_updatever;
+  }
 
-let run ~slots () =
+let sha256_and_sha1_file file =
+  let ctx256 = ref (Digestif.SHA256.init ()) in
+  let ctx1 = ref (Digestif.SHA1.init ()) in
+  Bos.OS.File.with_input ~bytes:(Bytes.create 32_768) file
+    (fun f () ->
+      let rec feedloop = function
+        | Some (b, pos, len) ->
+            ctx256 := Digestif.SHA256.feed_bytes !ctx256 ~off:pos ~len b;
+            ctx1 := Digestif.SHA1.feed_bytes !ctx1 ~off:pos ~len b;
+            feedloop (f ())
+        | None -> (Digestif.SHA256.get !ctx256, Digestif.SHA1.get !ctx1)
+      in
+      feedloop (f ()))
+    ()
+
+(** Subdirectories (called "addons" in Qt6) of https://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5152/
+    that are not in the base directory
+    https://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5152/qt.qt5.5152.win64_msvc2019_64/
+    
+    See https://doc.qt.io/qt-6/qtmodules.html and
+    https://aqtinstall.readthedocs.io/en/latest/getting_started.html#installing-a-subset-of-qt-archives-advanced *)
+let qt_nonbase_modules =
+  [
+    "qtcharts";
+    "qtdatavis3d";
+    "qtlottie";
+    "qtnetworkauth";
+    "qtpurchasing";
+    "qtquick3d";
+    "qtquicktimeline";
+    "qtscript";
+    "qtvirtualkeyboard";
+    "qtwebengine";
+    "qtwebglplugin";
+  ]
+
+let show_archive_server_contents ~archives_dir ~qt_abi ~qt_downloadver
+    ~qt_updatever ~aqt_target =
+  let open Bos in
+  let f_contents fpath acc =
+    let basename = Fpath.basename fpath in
+    (* https://github.com/miurahr/aqtinstall/blob/7917b2d725f56e8ceb6ba17b41ea0571506c7320/aqt/archives.py#L492-L499 *)
+    (* Example base:
+       https://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5152/qt.qt5.5152.win64_msvc2019_64/5.15.2-0-202011130602qtconnectivity-Windows-Windows_10-MSVC2019-Windows-Windows_10-X86_64.7z *)
+    (* Example nonbase:
+       https://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5152/qt.qt5.5152.qtwebengine.win64_msvc2019_64/5.15.2-0-202011130602qtwebengine-Windows-Windows_10-MSVC2019-Windows-Windows_10-X86_64.7z *)
+    let nonbase =
+      List.find_map
+        (fun nonbase_module ->
+          if String.starts_with basename ~prefix:(nonbase_module ^ "-") then
+            Some nonbase_module
+          else None)
+        qt_nonbase_modules
+    in
+    (* Example debuginfo:
+       https://mirrors.ocf.berkeley.edu/qt/online/qtsdkrepository/windows_x86/desktop/qt5_5152/qt.qt5.5152.debug_info.win64_msvc2019_64/5.15.2-0-202011130602qt3d-Windows-Windows_10-MSVC2019-Windows-Windows_10-X86_64-debug-symbols.7z *)
+    let debuginfo = String.ends_with basename ~suffix:"-debug-symbols.7z" in
+    let archive_path =
+      (* qt5_5152 -> qt5.5152 *)
+      let qt_download_ver_dot =
+        Stringext.replace_all qt_downloadver ~pattern:"_" ~with_:"."
+      in
+      (* qt.qt5.5152.win64_msvc2019_64 (base) or qt.qt5.5152.qtwebengine.win64_msvc2019_64 (nonbase) *)
+      let qt_module =
+        match (nonbase, debuginfo) with
+        | _, true ->
+            Printf.sprintf "qt.%s.debug_info.%s" qt_download_ver_dot aqt_target
+        | Some nonbase_module, false ->
+            Printf.sprintf "qt.%s.%s.%s" qt_download_ver_dot nonbase_module
+              aqt_target
+        | None, false ->
+            Printf.sprintf "qt.%s.%s" qt_download_ver_dot aqt_target
+      in
+      Printf.sprintf "online/qtsdkrepository/%s/desktop/%s/%s/%s%s" qt_abi
+        qt_downloadver qt_module qt_updatever basename
+    in
+    let sha256, sha1 =
+      let s256, s1 = sha256_and_sha1_file fpath |> Utils.rmsg in
+      (Digestif.SHA256.to_hex s256, Digestif.SHA1.to_hex s1)
+    in
+    let sha256_of_sha1 =
+      (* The content of a .sha1 file is the lowercase hex of the SHA1 with no CR or LF. *)
+      Digestif.SHA256.(to_hex (digest_string sha1))
+    in
+    `O
+      [
+        ("path_unencrypted", `String archive_path);
+        ("checksum", `O [ ("sha256", `String sha256) ]);
+      ]
+    :: `O
+         [
+           ("path_unencrypted", `String (archive_path ^ ".sha1"));
+           ("checksum", `O [ ("sha256", `String sha256_of_sha1) ]);
+         ]
+    :: acc
+  in
+  let contents =
+    OS.Dir.fold_contents
+      ~elements:(`Sat (fun fpath -> Ok (Fpath.get_ext fpath = ".7z")))
+      ~traverse:`None f_contents [] archives_dir
+    |> Utils.rmsg
+  in
+  print_endline (Ezjsonm.to_string ~minify:false (`A contents))
+
+let run ?create_archive ?host_abi ~slots () =
   Utils.start_step "Installing Qt";
   let open Bos in
   let cwd = OS.Dir.current () |> Utils.rmsg in
@@ -45,8 +179,24 @@ let run ~slots () =
      $ (source us/SonicScoutBackend/.tools/miniconda/bin/activate && conda run -n aqt aqt list-qt mac desktop --arch 5.15.2)
      clang_64 wasm_32
   *)
-  let { host; target; qt5_ver; subdir = _ } = qt_locations () in
-  if not (OS.Dir.exists Fpath.(projectdir / qt5_ver) |> Utils.rmsg) then begin
+  let {
+    aqt_host;
+    aqt_target;
+    aqt_subdir;
+    qt_ver;
+    qt_abi;
+    qt_downloadver;
+    qt_updatever;
+  } =
+    qt_locations ?host_abi ()
+  in
+  let qt5_dir = Fpath.(projectdir / qt_ver) in
+  let archives_dir = Fpath.(qt5_dir / aqt_subdir / "archives") in
+  if
+    (not (OS.Dir.exists qt5_dir |> Utils.rmsg))
+    || create_archive = Some ()
+       && not (OS.Dir.exists archives_dir |> Utils.rmsg)
+  then begin
     Logs.info (fun l ->
         l "Installing Qt modules. This may take %s minutes ..."
           (if Sys.win32 then "several" else "a few"));
@@ -54,6 +204,12 @@ let run ~slots () =
       match Slots.python_version slots with
       | None -> []
       | Some python_version -> [ "--python"; python_version ]
+    in
+    let archive_args =
+      if create_archive = Some () then
+        (* https://aqtinstall.readthedocs.io/en/latest/configuration.html *)
+        [ "--keep"; "--archive-dest"; Fpath.to_string archives_dir ]
+      else []
     in
     Utils.uv_run ~exclude_newer:"2025-01-04T00:00:00Z" ~slots
       (python_version_args
@@ -66,18 +222,36 @@ let run ~slots () =
           "install-qt";
           "-O";
           Fpath.to_string projectdir;
-          host;
+          aqt_host;
           "desktop";
-          qt5_ver;
-          target;
+          qt_ver;
+          aqt_target;
           "--base";
           "http://mirrors.ocf.berkeley.edu/qt/";
           "--modules";
           "all";
-        ])
-  end
+        ]
+      @ archive_args)
+  end;
+  if create_archive = Some () then
+    show_archive_server_contents ~archives_dir ~qt_abi ~qt_downloadver
+      ~qt_updatever ~aqt_target
 
 let __init () =
+  if Array.length Sys.argv <= 1 then
+    failwith
+      (Printf.sprintf "./dk %s windows_x86_64|darwin_arm64|..." __MODULE_ID__);
+  let host_abi =
+    match Sys.argv.(1) with
+    | "darwin_x86_64" -> `darwin_x86_64
+    | "darwin_arm64" -> `darwin_arm64
+    | "windows_x86_64" -> `windows_x86_64
+    | "windows_x86" -> `windows_x86
+    | "linux_x86_64" -> `linux_x86_64
+    | "linux_x86" -> `linux_x86
+    | _ ->
+        failwith "Currently your host machine is not supported by Sonic Scout"
+  in
   let slots = Slots.create () in
   let slots = Python.run ~slots () in
-  run ~slots ()
+  run ~create_archive:() ~host_abi ~slots ()

--- a/src/SonicScout_Setup/Scanner.ml
+++ b/src/SonicScout_Setup/Scanner.ml
@@ -21,7 +21,7 @@ let run ~slots () =
     Fpath.(
       ScoutBackend.build_reldir / "src" / "SonicScout_ManagerApp" // subpath)
   in
-  let { host = _; target = _; qt5_ver; subdir } : Qt.qt_locations =
+  let { qt_ver; aqt_subdir; _ } : Qt.qt_locations =
     Qt.qt_locations ()
   in
 
@@ -50,8 +50,8 @@ let run ~slots () =
   in
 
   (* Make Qt5 shared libraries available. *)
-  let qt_bin = Fpath.(projectdir / qt5_ver / subdir / "bin") in
-  let qt_projectrel_lib = Fpath.(v qt5_ver / subdir / "lib") in
+  let qt_bin = Fpath.(projectdir / qt_ver / aqt_subdir / "bin") in
+  let qt_projectrel_lib = Fpath.(v qt_ver / aqt_subdir / "lib") in
   let env = OS.Env.current () |> rmsg in
   let env =
     match Tr1HostMachine.os with

--- a/src/SonicScout_Setup/Utils.ml
+++ b/src/SonicScout_Setup/Utils.ml
@@ -183,7 +183,7 @@ let _uv_cache_args ~slots args =
   | None -> "--no-cache" :: args
   | Some cache_dir -> "--cache-dir" :: Fpath.to_string cache_dir :: args
 
-let _uv_more_args ~slots args =
+let _uv_core_args ~slots args =
   let args =
     (* Allow use in corporate environments, even if slower on macOS. *)
     "--native-tls" ::
@@ -195,11 +195,11 @@ let _uv_more_args ~slots args =
   in
   (* Never use system cache directory for repeatability *)
   _uv_cache_args ~slots args
-  [@ocamlformat "disable"]
+  [@@ocamlformat "disable"]
 
 let uv ?env ~slots args =
   let open Bos in
-  let args = _uv_more_args ~slots args in
+  let args = _uv_core_args ~slots args in
   Logs.info (fun l -> l "uv %a" (Fmt.list ~sep:Fmt.sp Fmt.string) args);
   let the_exe =
     match Slots.uv slots with Some exe -> Cmd.(v (p exe)) | None -> Cmd.v "uv"
@@ -208,7 +208,7 @@ let uv ?env ~slots args =
 
 let uv_out_string ?env ~slots args =
   let open Bos in
-  let args = _uv_more_args ~slots args in
+  let args = _uv_core_args ~slots args in
   Logs.info (fun l -> l "uv %a" (Fmt.list ~sep:Fmt.sp Fmt.string) args);
   let the_exe =
     match Slots.uv slots with Some exe -> Cmd.(v (p exe)) | None -> Cmd.v "uv"
@@ -229,18 +229,9 @@ let _uv_run_env ?global_pip_config () =
 
 let _uv_run_args ?exclude_newer ~slots () =
   let a =
-    [
-      "--no-env-file";
-      "--no-config";
-      "--native-tls";
-      "--python-preference";
-      "only-managed";
-    ]
-  in
-  let a =
     match exclude_newer with
-    | None -> a
-    | Some date -> a @ [ "--exclude-newer"; date ]
+    | None -> [ "--no-env-file" ]
+    | Some date -> [ "--no-env-file"; "--exclude-newer"; date ]
   in
   _uv_cache_args ~slots a
 

--- a/src/SonicScout_Setup/assets__/qt-settings.ini
+++ b/src/SonicScout_Setup/assets__/qt-settings.ini
@@ -1,0 +1,265 @@
+# Copied from https://github.com/miurahr/aqtinstall/blob/a30f5a3d055f954e3c89c05ffbf5d98dd8124520/aqt/settings.ini
+# with the following changes:
+# - aqt.baseurl
+#   CHANGE from [https://download.qt.io] to [https://diskuv.com/a/qt-desktop/5.15.2]
+# - mirrors.trusted_mirrors
+#   PREPEND [https://diskuv.com/a/qt-desktop/5.15.2]
+[DEFAULTS]
+
+[aqt]
+concurrency : 4
+# baseurl : https://download.qt.io
+baseurl : https://diskuv.com/a/qt-desktop/5.15.2
+7zcmd : 7z
+print_stacktrace_on_error : False
+always_keep_archives : False
+archive_download_location : .
+min_module_size : 41
+
+[requests]
+connection_timeout : 3.5
+response_timeout : 30
+max_retries_on_connection_error : 5
+retry_backoff : 0.1
+max_retries_on_checksum_error : 5
+max_retries_to_retrieve_hash : 5
+hash_algorithm : sha256
+INSECURE_NOT_FOR_PRODUCTION_ignore_hash : False
+
+[qtcommercial]
+unattended : True
+installer_timeout : 1800
+operation_does_not_exist_error : Ignore
+overwrite_target_directory : Yes
+stop_processes_for_updates : Ignore
+installation_error_with_cancel : Ignore
+installation_error_with_ignore : Ignore
+associate_common_filetypes : Yes
+telemetry : No
+cache_path :
+temp_dir :
+
+[mirrors]
+trusted_mirrors :
+    https://diskuv.com/a/qt-desktop/5.15.2
+    https://download.qt.io
+blacklist :
+    http://mirrors.ocf.berkeley.edu
+    http://mirrors.tuna.tsinghua.edu.cn
+    http://mirrors.geekpie.club
+fallbacks :
+    https://diskuv.com/a/qt-desktop/5.15.2
+    https://qtproject.mirror.liquidtelecom.com/
+    https://mirrors.aliyun.com/qt/
+    https://mirrors.ustc.edu.cn/qtproject/
+    https://ftp.jaist.ac.jp/pub/qtproject/
+    https://ftp.yz.yamagata-u.ac.jp/pub/qtproject/
+    https://qt-mirror.dannhauer.de/
+    https://ftp.fau.de/qtproject/
+    https://mirror.netcologne.de/qtproject/
+    https://mirrors.dotsrc.org/qtproject/
+    https://www.nic.funet.fi/pub/mirrors/download.qt-project.org/
+    https://master.qt.io/
+    https://mirrors.ukfast.co.uk/sites/qt.io/
+    https://ftp2.nluug.nl/languages/qt/
+    https://ftp1.nluug.nl/languages/qt/
+    https://qt.mirror.constant.com/
+
+[kde_patches]
+patches :
+    0001-toolchain.prf-Use-vswhere-to-obtain-VS-installation-.patch
+    0002-Fix-allocated-memory-of-QByteArray-returned-by-QIODe.patch
+    0003-Update-CLDR-to-v37-adding-Nigerian-Pidgin-as-a-new-l.patch
+    0004-QLayout-docs-explain-better-what-the-QWidget-ctor-ar.patch
+    0005-QMacStyle-fix-tab-rendering.patch
+    0006-QMacStyle-more-pixel-refinements.patch
+    0007-Deprecate-ordering-on-QItemSelectionRange.patch
+    0008-Deprecate-QLocale-Language-entries-that-no-locale-da.patch
+    0009-Deprecate-old-aliases-for-two-countries-and-several-.patch
+    0010-QAbstractItemModelTester-don-t-rely-on-hasChildren.patch
+    0011-Doc-Remove-mentioning-of-old-macos-versions-from-QSe.patch
+    0012-Pass-SameSite-through-QNetworkCookie.patch
+    0013-doc-fix-typo-consise-concise.patch
+    0014-Selftest-copy-XAUTHORITY-environment-variable.patch
+    0015-Fix-delay-first-time-a-font-is-used.patch
+    0016-Fix-QScreen-orientation-not-being-updated-when-setti.patch
+    0017-Android-Request-cursor-to-be-in-proper-position.patch
+    0018-testlib-Let-logger-report-whether-it-is-logging-to-s.patch
+    0019-Android-disable-Gradle-caching-by-default.patch
+    0020-Android-replace-stacktrace-with-debug-message-in-sea.patch
+    0021-Use-void-instead-of-Q_UNUSED.patch
+    0022-Don-t-show-QPushButton-as-hovered-unless-the-mouse-i.patch
+    0023-MinGW-Fix-assert-in-QCoreApplication-arguments-when-.patch
+    0024-QCombobox-propagate-the-palette-to-the-embedded-line.patch
+    0025-QMarginsF-document-that-isNull-operator-operator-are.patch
+    0026-qmake-vcxproj-Fix-handling-of-extra-compiler-outputs.patch
+    0027-Android-fix-documentation-about-ANDROID_EXTRA_LIBS.patch
+    0028-Offscreen-QPA-implement-a-native-interface.patch
+    0029-DropSite-example-support-markdown.patch
+    0030-Do-not-define-dynamic_cast.patch
+    0031-Android-fix-crash-by-passing-the-right-Handle-to-dls.patch
+    0032-testlib-Add-private-API-to-add-test-logger.patch
+    0033-Update-third-party-md4c-to-version-0.4.6.patch
+    0034-moc-Handle-include-in-enum-take-2.patch
+    0035-InputMethod-should-call-reset-function-when-proxywid.patch
+    0036-Add-possibility-to-set-QNX-Screen-pipeline-value.patch
+    0037-qglobal-Only-define-QT_ENSURE_STACK_ALIGNED_FOR_SSE-.patch
+    0038-macOS-FreeType-fix-crash-with-non-printable-unicode.patch
+    0039-Linux-fix-crash-in-AtSpi-adaptor-when-handling-windo.patch
+    0040-Add-_MSC_VER-check-to-MSVC-ARM-compiler-workaround.patch
+    0041-QMap-suppress-warning-about-strict-aliasing-violatio.patch
+    0042-Add-changes-file-for-Qt-5.15.2.patch
+    0043-Set-the-url-to-have-the-AtNx-filename-if-one-is-foun.patch
+    0044-QMap-don-t-tell-everyone-QMapNode-has-no-friends.patch
+    0045-QNAM-Work-around-QObject-finicky-orphan-cleanup-deta.patch
+    0046-xcb-ensure-that-available-glx-version-is-greater-tha.patch
+    0047-Protect-QImage-colorspace-transform-on-shutdown.patch
+    0048-Fix-qstylesheetstyle-clip-border-error.patch
+    0049-Correct-processEvents-documentation.patch
+    0050-Update-CLDR-to-v38.patch
+    0051-Fix-compilation-when-using-no-mimetype-database.patch
+    0052-Reduce-memory-reallocations-in-QTextTablePrivate-upd.patch
+    0053-Fix-regular-expression-initialize-with-incorrect-fil.patch
+    0054-Cocoa-Allow-CMD-H-to-hide-the-application-when-a-too.patch
+    0055-Fix-pcre2-feature-conditions.patch
+    0056-Q_PRIMITIVE_TYPE-improve-the-documentation.patch
+    0057-QAsn1Element-Read-value-in-blocks-to-avoid-oom-at-wr.patch
+    0058-Android-Don-t-use-putIfAbsent-as-that-is-not-availab.patch
+    0059-QMutex-order-reads-from-QMutexPrivate-waiters-and-QB.patch
+    0060-Android-Add-the-QtAndroidBearer.jar-to-the-jar-depen.patch
+    0061-Android-Add-the-required-linker-flags-for-unwinding-.patch
+    0062-Android-recommend-against-using-ANDROID_ABIS-inside-.patch
+    0063-Android-fix-android-java-and-templates-targets-with-.patch
+    0064-QCharRef-properly-disable-assignment-from-char.patch
+    0065-Android-Treat-ACTION_CANCEL-as-TouchPointReleased.patch
+    0066-Fix-misidentification-of-some-shearing-QTransforms-a.patch
+    0067-Fix-QGraphicsItem-crash-if-click-right-button-of-mou.patch
+    0068-Bump-version.patch
+    0069-Android-Ensure-windows-always-have-a-geometry-on-cre.patch
+    0070-macOS-Account-for-Big-Sur-always-enabling-layer-back.patch
+    0071-Fix-shaping-problems-on-iOS-14-macOS-11.patch
+    0072-Link-to-qAlpha-in-qRgb-and-qRgba-docs.patch
+    0073-HTTP2-fix-crash-from-assertion.patch
+    0074-Fuzzing-Add-a-test-for-QDateTime-fromString.patch
+    0075-QSocks5SocketEngine-Fix-out-of-bounds-access-of-QBA.patch
+    0076-Use-QTRY_COMPARE-in-an-attempt-to-make-the-test-less.patch
+    0077-Doc-Document-QGradient-Preset-enum-values.patch
+    0078-Doc-Fix-documentation-warnings-for-Qt-XML.patch
+    0079-Doc-Fix-documentation-warnings-in-Qt-Network.patch
+    0080-Ensure-that-QMenu-is-polished-before-setting-the-scr.patch
+    0081-widgets-Don-t-report-new-focus-object-during-clearFo.patch
+    0082-QDtls-remove-redundant-RAII-struct.patch
+    0083-macOS-Propagate-device-pixel-ratio-of-system-tray-ic.patch
+    0084-tst_qocsp-improve-code-coverage.patch
+    0085-Doc-explain-how-to-create-a-test-touch-device-for-us.patch
+    0086-macOS-Upgrade-supported-SDK-to-11.0.patch
+    0087-Fix-logic-error-in-QString-replace-ch-after-cs.patch
+    0088-Be-more-consistent-when-converting-JSON-values-from-.patch
+    0089-QCoreApplication-add-more-information-to-processEven.patch
+    0090-Fix-QSFPM-not-emitting-dataChanged-when-source-model.patch
+    0091-Android-Fix-android-accessibility-not-being-set-acti.patch
+    0092-Fix-x-height-name-in-stylesheet-docs.patch
+    0093-QMutex-Work-around-ICC-bug-in-dealing-with-constexpr.patch
+    0094-wasm-fix-resizing-of-qwidget-windows.patch
+    0095-Avoid-integer-overflow-and-division-by-zero.patch
+    0096-QPasswordDigestor-improve-code-coverage.patch
+    0097-QStackedLayout-fix-a-memory-leak.patch
+    0098-Limit-value-in-setFontWeightFromValue.patch
+    0099-Doc-Fix-documentation-of-qmake-s-exists-function.patch
+    0100-QVLA-do-not-include-QtTest.patch
+    0101-Clean-up-docs-of-QCalendar-related-QLocale-toString-.patch
+    0102-Change-android-target-SDK-version-to-29.patch
+    0103-QVLA-always-use-new-to-create-new-objects.patch
+    0104-QPushButton-fix-support-of-style-sheet-rule-for-text.patch
+    0105-Limit-pen-width-to-maximal-32767.patch
+    0106-Doc-Consistently-use-book-style-capitalization-for-Q.patch
+    0107-qstring.h-fix-warnings-about-shortening-qsizetype-to.patch
+    0108-Fix-invalid-QSortFilterProxyModel-dataChanged-parame.patch
+    0109-Minor-refactor-of-installMetaFile.patch
+    0110-Return-a-more-useful-date-time-on-parser-failure-in-.patch
+    0111-QCalendar-increase-coverage-by-tests.patch
+    0112-Bounds-check-time-zone-offsets-when-parsing.patch
+    0113-Network-self-test-make-it-work-with-docker-container.patch
+    0114-QSslConfiguration-improve-code-coverage.patch
+    0115-Add-new-way-to-mess-up-projects-with-QMAKE_INSTALL_R.patch
+    0116-Install-3rd-party-headers-and-meta-for-static-builds.patch
+    0117-Create-qtlibjpeg-for-jpeg-image-plugin.patch
+    0118-QStandardPaths-Don-t-change-permissions-of-XDG_RUNTI.patch
+    0119-tst_QSslCertificate-improve-code-coverage.patch
+    0120-Let-QXcbConnection-getTimestamp-properly-exit-when-X.patch
+    0121-QDtls-cookie-verifier-make-sure-a-server-can-re-use-.patch
+    0122-QMacStyle-remove-vertical-adjustment-for-inactive-ta.patch
+    0123-Revert-xcb-add-xcb-util-dependency-for-xcb-image.patch
+    0124-Containers-call-constructors-even-for-primitive-type.patch
+    0125-Android-print-tailored-warning-if-qml-dependency-pat.patch
+    0126-Cosmetic-stroker-avoid-overflows-for-non-finite-coor.patch
+    0127-QSslCipher-improve-its-code-coverage-and-auto-tests.patch
+    0128-tst_qsslkey-handle-QT_NO_SSL-properly.patch
+    0129-Add-the-Qt-6.0-deprecation-macros.patch
+    0130-wasm-fix-mouse-double-click.patch
+    0131-Android-avoid-reflection-with-ClipData-addItem.patch
+    0132-QHeaderView-fix-spurious-sorting.patch
+    0133-Fix-exception-with-Android-5.x.patch
+    0134-Http2-Remove-errored-out-requests-from-queue.patch
+    0135-Http2-don-t-call-ensureConnection-when-there-s-no-re.patch
+    0136-Fix-QTranslator-load-search-order-not-following-uiLa.patch
+    0137-Avoid-signed-overflow-in-moc.patch
+    0138-Android-Kill-calls-to-deprecated-func-in-API-29.patch
+    0139-Doc-Improve-_CAST_FROM_ASCII-documentation.patch
+    0140-Improve-documented-function-argument-names.patch
+    0141-Fix-QImage-setPixelColor-on-RGBA64_Premultiplied.patch
+    0142-macOS-Make-sure-that-the-reserved-characters-are-not.patch
+    0143-Enable-testing-for-whether-a-calendar-registered-its.patch
+    0144-tests-add-a-shortcut-to-quit-app-in-allcursors.patch
+    0145-QSslSocket-Don-t-call-transmit-in-unencrypted-mode.patch
+    0146-QStringView-operator-operator-operator-currently-Qt6.patch
+    0147-QCborStreamReader-move-the-readStringChunk-code-to-t.patch
+    0148-Improve-the-documentation-for-QElapsedTimer-restart-.patch
+    0149-QSslSocket-verify-do-not-alter-the-default-configura.patch
+    0150-Fix-tst_QFontDatabase-aliases-failure-with-ambiguous.patch
+    0151-QStyleAnimation-make-sure-the-last-frame-of-animatio.patch
+    0152-PCRE-update-to-10.36.patch
+    0153-tst_QCborValue-adjust-the-size-of-the-minimum-string.patch
+    0154-macOS-Always-allow-interacting-with-popup-windows-du.patch
+    0155-macOS-Add-missing-QT_MANGLE_NAMESPACE.patch
+    0156-QSplashScreen-draw-pixmap-with-SmoothTransfrom.patch
+    0157-Android-Qml-accessibility-fixes.patch
+    0158-Http2-set-the-reply-s-error-code-and-string-on-error.patch
+    0159-Try-again-to-fix-Clang-s-Wconstant-logical-operand-w.patch
+    0160-Revert-Android-print-tailored-warning-if-qml-depende.patch
+    0161-QUrl-fix-parsing-of-empty-IPv6-addresses.patch
+    0162-tst_QSslError-improve-the-code-coverage-as-pointed-a.patch
+    0163-macOS-Disable-WA_QuitOnClose-on-menu-item-widget-con.patch
+    0164-QString-fix-count-QRegularExpression.patch
+    0165-QString-lastIndexOf-fix-off-by-one-for-zero-length-m.patch
+    0166-secureudpclient-a-speculative-fix-for-non-reproducib.patch
+    0167-Android-don-t-use-avx-and-avx2-when-building-for-And.patch
+    0168-Fuzzing-Provide-link-to-oss-fuzz.patch
+    0169-Blacklist-tst_QMdiArea-updateScrollBars-on-macos.patch
+    0170-Fix-build-with-GCC-11-include-limits.patch
+    0171-Build-fixes-for-GCC-11.patch
+    0172-Partially-revert-813a928c7c3cf98670b6043149880ed5c95.patch
+    0173-Fix-removing-columns-when-QSortFilterProxyModel-has-.patch
+    0174-Fix-get-out-of-bounds-index-in-QSortFilterProxyModel.patch
+    0175-Fix-handling-of-surrogates-in-QBidiAlgorithm.patch
+    0176-Avoid-undefined-color-values-in-corrupt-xpm-image.patch
+    0177-Gracefully-reject-requests-for-absurd-font-sizes.patch
+    0178-Don-t-own-unique-name-for-QDBusTrayIcon.patch
+    0179-QAbstractItemModelTester-fix-false-positive-when-mod.patch
+    0180-Fix-QAbstractItemModelTester-false-positive.patch
+    0181-Deprecate-QMutex-in-recursive-mode.patch
+    0182-Fix-QAbstractItemModelTester-false-positive.patch
+    0183-Fix-crash-on-serializing-default-constructed-QTimeZo.patch
+    0184-Fix-QTreeModel-calling-beginRemoveRows-twice.patch
+    0185-QConcatenateTablesProxyModel-skip-dataChanged-in-hid.patch
+    0186-QComboBox-fix-select-all-columns-in-the-view.patch
+    0187-QTableView-honor-spans-when-calculating-height-width.patch
+    0188-TableView-Trigger-the-resizing-of-editors-resizing-a.patch
+    0189-Fix-no-mapping-for-SysReq-key.patch
+    0190-qdbus-add-support-for-aay-QByteArrayList.patch
+    0191-QRandom-drop-a-usage-of-std-is_literal_type.patch
+    0192-fix-Optimize-the-performance-of-the-inotify-file-sys.patch
+    0193-Remove-the-unnecessary-template-parameter-from-the-c.patch
+    0194-Fix-memory-leak-when-using-small-caps-font.patch
+    0195-Make-sure-_q_printerChanged-is-called-even-if-only-p.patch
+    0196-fix-Alt-shortcut-on-non-US-layouts.patch

--- a/src/SonicScout_Setup/open__.ml
+++ b/src/SonicScout_Setup/open__.ml
@@ -24,3 +24,4 @@ module Uchar = Tr1Stdlib_V414Base.Uchar
 module Ezjsonm = Tr1Json_Std.Ezjsonm
 module Fpath = Tr1Fpath_Std.Fpath
 module Cmdliner = Tr1Cmdliner_Std.Cmdliner
+let print_endline = Tr1Stdlib_V414Io.StdIo.print_endline

--- a/us/SonicScoutBackend/.gitignore
+++ b/us/SonicScoutBackend/.gitignore
@@ -56,7 +56,8 @@ user.envrc
 
 # Qt
 /aqtinstall.log
-/5.15.2
+/5.*.*
+/6.*.*
 
 # Parent `scoutapps`'s ./dk DkRun_V0_4.Run -- src/SonicScout_Setup/Package.ml --notarize
 /sign/


### PR DESCRIPTION
The root cause of #21 is that the Qt mirror used by scoutapps (`http://mirrors.ocf.berkeley.edu/qt/`) was throttling users. I finally experienced it once at home, and same with @wolflegend523 , and the site had been put on a "blacklist" for mirrors.

The solution was to place all the content needed by Qt behind a reliable mirror which I know won't throttle users (my own site). Also placing downloads on my site makes it easy for institutional firewalls to just allow `https://diskuv.com` going forward rather than random places on the Internet.

The PR is split into two parts:

1. Commit "Use custom aqt settings for Qt mirror": Stop using `--base http://mirrors.ocf.berkeley.edu/qt/` which forced the use of a bad mirror for the big files but defaulted to `https://download.qt.io` for the small "trusted" checksum files. Instead use `--config ..../qt-settings.ini` which has better configuration ... I have set that to go to `https://diskuv.com/a/qt-desktop/5.15.2` for both trusted checksums and the big files. In my testing only `https://diskuv.com` was accessed with the new configuration.
2. Commit "Add an option to save the Qt archive files": A feature to export all the Qt URLs and checksums needed into a single JSON array. I use that JSON array in a backend job for my website so I can make an exact, permanent mirror.

### Testing

Just blow away the directory `us\SonicScoutBackend\5.15.2\msvc2019_64` and then run `./dk SonicScout_Setup.Qt windows_x86_64`