### PR TITLE
Allow full Visual Studio IDE

### DIFF
--- a/src/SonicScout_Setup/Develop.ml
+++ b/src/SonicScout_Setup/Develop.ml
@@ -16,6 +16,7 @@ let _compile_base ?skip_android ({ dksdk_data_home; opts; global_dkml } as commo
 
   InitialSteps.run ~dksdk_data_home ();
   let slots = Slots.create () in
+  let slots = VisualStudio.run ?global_dkml ~slots () in
   let slots = DkML.run ?global_dkml ~slots () in
   let slots = _compile_backend ~slots common in
   let slots =

--- a/src/SonicScout_Setup/DkML.ml
+++ b/src/SonicScout_Setup/DkML.ml
@@ -10,17 +10,6 @@ let find_dkml_win32 () =
 
 let run_win32 ?global_dkml ~slots () =
   let open Bos in
-  if
-    not
-      (OS.File.exists (Fpath.v {|C:\VS\Common7\Tools\VsDevCmd.bat|})
-      |> Utils.rmsg)
-  then
-    Winget.install
-      [
-        "Microsoft.VisualStudio.2019.BuildTools";
-        "--override";
-        {|--wait --passive --installPath C:\VS --addProductLang En-us --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended|};
-      ];
   let slots =
     if OS.Cmd.exists Cmd.(v "git") |> Utils.rmsg then slots
     else begin

--- a/src/SonicScout_Setup/Package.ml
+++ b/src/SonicScout_Setup/Package.ml
@@ -5,6 +5,7 @@ let package ({ dksdk_data_home; opts; global_dkml } : Develop.common) notarize =
     Qt.run ();
     Sqlite3.run ();
     let slots = Slots.create () in
+    let slots = VisualStudio.run ?global_dkml ~slots () in
     let slots = DkML.run ?global_dkml ~slots () in
     let slots = ScoutBackend.run ?global_dkml ~opts ~slots () in
     ScoutBackend.package ~notarize ();

--- a/src/SonicScout_Setup/RunCMake.ml
+++ b/src/SonicScout_Setup/RunCMake.ml
@@ -17,7 +17,7 @@ open Bos
 (* Ported from Utils since this script is standalone. *)
 let rmsg = function Ok v -> v | Error (`Msg msg) -> failwith msg
 
-let run ?debug_env ?env ?global_dkml ~projectdir ~name ~slots args =
+let run ?debug_env ?env ~projectdir ~name ~slots args =
   let tools_dir = Fpath.(projectdir / ".tools") in
   let env =
     match env with Some env -> env | None -> OS.Env.current () |> rmsg
@@ -41,16 +41,7 @@ let run ?debug_env ?env ?global_dkml ~projectdir ~name ~slots args =
          Confer:
            https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022
            https://devblogs.microsoft.com/visualstudio/say-hello-to-the-new-visual-studio-terminal/ *)
-      let vsstudio_dir =
-        match global_dkml with
-        | Some () ->
-            OS.File.read
-              Fpath.(
-                v (Sys.getenv "LOCALAPPDATA")
-                / "Programs" / "DkML" / "vsstudio.dir.txt")
-            |> rmsg |> String.trim |> Fpath.v
-        | None -> Fpath.v "C:/VS"
-      in
+      let vsstudio_dir = Slots.vsdir_exn slots in
       let quoted_cmdargs =
         Fpath.to_string cmake :: args |> List.map Filename.quote
       in

--- a/src/SonicScout_Setup/ScoutBackend.ml
+++ b/src/SonicScout_Setup/ScoutBackend.ml
@@ -225,9 +225,9 @@ let run ?(opts = Utils.default_opts) ?global_dkml ~slots () =
           (OS.File.read (Fpath.v "CMakeUserPresets-SUGGESTED.json") |> rmsg)
         |> rmsg;
 
-      RunCMake.run ?global_dkml ~projectdir ~name:"backend-preset" ~slots
+      RunCMake.run ~projectdir ~name:"backend-preset" ~slots
         ([ "--preset"; preset ] @ cmake_properties ~cwd ~opts slots);
-      RunCMake.run ?global_dkml ~projectdir ~name:"backend-build" ~slots
+      RunCMake.run ~projectdir ~name:"backend-build" ~slots
         [
           "--build";
           Fpath.to_string build_reldir;

--- a/src/SonicScout_Setup/Slots.ml
+++ b/src/SonicScout_Setup/Slots.ml
@@ -3,6 +3,7 @@
 type t = {
   msys2 : Fpath.t option;
   git : Fpath.t option;
+  vsdir : Fpath.t option;
   uv : Fpath.t option;
   uv_cache : Fpath.t option;
   uv_install : Fpath.t option;
@@ -14,6 +15,7 @@ let create () =
   {
     msys2 = None;
     git = None;
+    vsdir = None;
     uv = None;
     uv_cache = None;
     uv_install = None;
@@ -26,6 +28,8 @@ let add_msys2 t fp = { t with msys2 = Some fp }
 let add_git t git_exe =
   let fp_dir = Fpath.parent git_exe in
   { t with git = Some git_exe; paths = fp_dir :: t.paths }
+
+let add_vsdir t vsdir = { t with vsdir = Some vsdir }
 
 let add_uv ~cache_dir t uv_exe =
   let fp_dir = Fpath.parent uv_exe in
@@ -44,6 +48,15 @@ let paths { paths; _ } = paths
 let msys2 { msys2; _ } = msys2
 let git { git; _ } = git
 let uv { uv; _ } = uv
+
+let vsdir_exn { vsdir; _ } =
+  match vsdir with
+  | None ->
+      failwith
+        "The [vsdir] slot has not been filled. Make sure the setup script \
+         calls [VisualStudio.run]"
+  | Some v -> v
+
 let uv_cache { uv_cache; _ } = uv_cache
 let uv_install { uv_install; _ } = uv_install
 let python_version { python_version; _ } = python_version

--- a/src/SonicScout_Setup/VisualStudio.ml
+++ b/src/SonicScout_Setup/VisualStudio.ml
@@ -1,0 +1,56 @@
+(* This script is standalone. *)
+let rmsg = function Ok v -> v | Error (`Msg msg) -> failwith msg
+
+(** Search standard places for Visual Studio. *)
+let find_vsdir () =
+  let open Bos in
+  let is_vsdir candidate =
+    (* Common7\Tools\Microsoft.VisualStudio.DevShell.dll needed for RunCMake *)
+    OS.File.exists
+      Fpath.(
+        candidate / "Common7" / "Tools" / "Microsoft.VisualStudio.DevShell.dll")
+    |> rmsg
+  in
+  let search =
+    (* Eventually we should download vswhere.exe and use it. Also 2022 should work. *)
+    List.map Fpath.v
+      [
+        {|C:\VS|};
+        {|C:\Program Files (x86)\Microsoft Visual Studio\2019\Community|};
+        {|C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional|};
+        {|C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise|};
+      ]
+  in
+  List.find_opt is_vsdir search
+
+let run ?global_dkml ~slots () =
+  Utils.start_step "Installing Visual Studio";
+  let open Bos in
+  let vsdir_opt =
+    match global_dkml with
+    | None ->
+        (* Search standard places for Visual Studio *)
+        find_vsdir ()
+    | Some () -> (
+        (* If we have DkML installed try to use its Visual Studio installation. *)
+        let vsdirtxt =
+          Fpath.(
+            v (Sys.getenv "LOCALAPPDATA")
+            / "Programs" / "DkML" / "vsstudio.dir.txt")
+        in
+        match OS.File.read vsdirtxt with
+        | Ok contents -> Some (Fpath.v (String.trim contents))
+        | Error _ ->
+            (* If we can't find it, do a standard search *)
+            find_vsdir ())
+  in
+  match vsdir_opt with
+  | Some vsdir -> Slots.add_vsdir slots vsdir
+  | None ->
+      Winget.install
+        [
+          "Microsoft.VisualStudio.2019.BuildTools";
+          "--override";
+          {|--wait --passive --installPath C:\VS --addProductLang En-us --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended|};
+        ];
+      Slots.add_vsdir slots (Fpath.v {|C:\VS|})


### PR DESCRIPTION
In GP the full Visual Studio 2019 Community IDE was installed rather than Visual Studio 2019 Build Tools. The full IDE has a stricter license but is fine in a school.

This PR will:

- search for the standard locations of Visual Studio 2019
- stick the found location into the "slots"
- use the found location from the slot in RunCMake

(Written by Jonah)